### PR TITLE
fix bad leftover code

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -1175,9 +1175,7 @@ class Event_sched_stat (Event):
 			task = tasks[self.tid]
 			self.cpu = task.cpu
 		except:
-			# this is just a best guess
-			# for this never-seen-before task
-			self.cpu = cpu
+			pass
 
 		task = super(Event_sched_stat, self).process()
 


### PR DESCRIPTION
There are a few lines of code leftover from before the redesign to
support out-of-order events (commit e84450592b0d5c6778c135c43762a485f9ed634d)
which use a now uninitialized variable, `cpu`.

These lines are obsoleted by the change (`self.cpu` is now set in the
creation of the `Event_sched_stat` instance), and are no longer required.

This bug is triggered if the first event seen for a task is a `sched_stat`
event.

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>