### PR TITLE
fix recording with command and arguments

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -55,7 +55,7 @@ parser.add_argument('--record',
 		"Specify event group(s) as a comma-separated list from "
 		"{all,sched,stats,syscalls,irqs,hcalls}.")
 parser.add_argument('file_or_command',
-	nargs='*',
+	nargs=argparse.REMAINDER,
 	help="the perf format data file to process (default: \"perf.data\"), or "
 		"the command string to record (with \"--record\")",
 	metavar='ARG',


### PR DESCRIPTION
`curt` failed to run if recording and the given command included arguments.
```
$ ./curt.py --record all /bin/ls -l
usage: curt.py [-h] [--debug] [--window WINDOW] [--api API]
               [--record EVENTLIST]
               [ARG [ARG ...]]
curt.py: error: unrecognized arguments: -l
```
Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>