### PR TITLE
fix curt when not recording

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -96,13 +96,15 @@ if params.record:
 	if params.debug:
 		print command
 	subprocess.call(command)
-	params.file_or_command = "perf.data"
+	params.file_or_command = []
 
 try:
 	from perf_trace_context import *
 except:
 	print "Relaunching under \"perf\" command..."
-	sys.argv = ['perf', 'script', '-i', params.file_or_command, '-s', sys.argv[0] ]
+	if len(params.file_or_command) == 0:
+		params.file_or_command = [ "perf.data" ]
+	sys.argv = ['perf', 'script', '-i' ] + params.file_or_command + [ '-s', sys.argv[0] ]
 	sys.argv.append('--')
 	sys.argv += ['--window', str(params.window)]
 	if params.debug:


### PR DESCRIPTION
Oops.  Recent recording changes broke the non-recording use:
```
$ ./curt.py --debug
Relaunching under "perf" command...
['perf', 'script', '-i', [], '-s', './curt.py', '--', '--window', '20', '--debug', '--api', '1']
Traceback (most recent call last):
  File "./curt.py", line 113, in <module>
    os.execvp("perf", sys.argv)
  File "/usr/lib64/python2.7/os.py", line 344, in execvp
    _execvpe(file, args)
  File "/usr/lib64/python2.7/os.py", line 380, in _execvpe
    func(fullname, *argrest)
TypeError: execv() arg 2 must contain only strings
```

The `params.file_or_command` variable is a list, so instead of embedding it,
it should be concatenated.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>