### PR TITLE
use parent state to initialize new child task

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -1090,22 +1090,14 @@ class Event_sched_process_fork (Event):
 			parent = tasks[self.parent_tid]
 		except:
 			# need to create parent task here!
-			sys.exit(1)
-			parent = Task()
-			parent.timestamp = start_timestamp
-			parent.command = self.command
-			parent.mode = 'sys'
+			parent = Task(start_timestamp, self.command, 'sys', self.pid)
 			parent.sched_stat = True # ?
 			parent.cpu = self.cpu
 			parent.cpus[parent.cpu] = CPU()
 			tasks[self.parent_tid] = parent
 
-		task.timestamp = self.timestamp
-		task.command = self.command
-		task.mode = 'idle'
 		task.resume_mode = parent.mode # ? 'sys' ?
 		task.sched_stat = True # ?
-		task.pid = 'unknown' # ?
 		task.syscall = parent.syscall
 		task.syscalls[task.syscall] = Call()
 		task.syscalls[task.syscall].timestamp = self.timestamp


### PR DESCRIPTION
Currently, when a new task is created, curt will synthesize
a `clone` system call entry to set the initial state of the task.
Unfortunately, this requires knowing the numeric code of the
`clone` system call, which is architecture-dependent and for
which there is no easy mapping from the name.  An exhaustive
search is done (only once) through every likely valid numeric code
(and then some).

A better approach is to _clone_ the state from the parent
task, because it is indeed in a `clone` system call itself,
so no search is required for the numeric code, as it can be simply
extracted from the parent.

The new edge case that must be handled is when the first
event for the _parent_ is a `sched_process_fork`.  In this case,
a `Task` must be created and initialized for the parent task.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>