### PR TITLE
relaunch only for API errors

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -125,7 +125,7 @@ except:
 # exception, we attempt to revert to the older perf event handler API.
 
 def checkAPI(t, val, backtrace):
-	if t == TypeError and str(val).find('takes exactly'):
+	if t == TypeError and str(val).find('takes exactly') >= 0:
 		# remove any existing "--api" parameters
 		new_argv = []
 		arg = 0


### PR DESCRIPTION
An incorrect test was being used to test for an API-related exception,
resulting in a relaunch even for non-API related exceptions, resulting
in an infinite loop:
```
$ ./curt.py
Relaunching under "perf" command...
Relaunching under "perf" command...
Relaunching under "perf" command...
```

Fixed to report the actual exception and exit:
```
$ ./curt.py
Relaunching under "perf" command...
Traceback (most recent call last):
  File "./curt.py", line 680, in raw_syscalls__sys_exit_new
    process_event(event)
  File "./curt.py", line 527, in process_event
    event.process()
  File "./curt.py", line 1202, in process
    task = super(Event_sched_stat, self).process()
  File "./curt.py", line 552, in process
    debug_print("%016u %7s/%06u [%03u] %-32s\n\tnew Task" % (self.timestamp, str(self.pid), self.tid, self.cpu, self.__class__.__name__))
TypeError: %u format: a number is required, not str
Fatal Python error: problem in Python trace event handler
Aborted

```

Fixes #40

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>