### PR TITLE
Fix crash with exec-sched_stat sequence

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -1045,6 +1045,8 @@ class Event_sched_process_exec (Event):
 		new_task.syscall = task.syscall
 		new_task.syscalls[task.syscall] = Call()
 		new_task.syscalls[task.syscall].timestamp = self.timestamp
+		new_task.cpu = self.cpu
+		new_task.cpus[self.cpu] = CPU()
 
 		# close out current task stats and stow them somewhere,
 		# because we're reusing the TID for a new process image,


### PR DESCRIPTION
When a new Task is created for sched_process_exec event, the Task's
"cpu" is left "unknown".  If the next event for the Task is a
sched_stat, since it presumes its own CPU is not valid, it will
further presume that the Task's CPU is valid and try to use it.
Since it is still "unknown", some odd and bad things can happen,
including a crash in the debug_print statement when attempting
to format the Task's "cpu" as an integer type.

Fix by always setting up the newly exec'd Task's CPU information
based on the old Task's current CPU.

Fixes #42

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>