### PR TITLE
Better handle bytearrays

### DIFF
--- a/curt.py
+++ b/curt.py
@@ -291,6 +291,7 @@ def null(ba):
 		null = ba.find(b'\x00')
 		if null >= 0:
 			ba = ba[0:null]
+		ba = ba.decode()
 	except: pass
 	return str(ba)
 


### PR DESCRIPTION
Command strings are actually received from perf as bytearrays.
More carefully convert uniformly to strings.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>